### PR TITLE
Potential fix for code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/dash_service/app.py
+++ b/dash_service/app.py
@@ -117,6 +117,13 @@ def reroute_transmonee_root():
 
 @server.route("/transmonee/<path:page>")
 def reroute_transmonee(page):
+    if (
+        not page
+        or page.startswith(("/", "\\"))
+        or any(ch in page for ch in ("\r", "\n", "\t", "\x00"))
+    ):
+        return redirect("/?prj=tm")
+
     query = urlencode({"prj": "tm", "page": page})
     return redirect(f"/?{query}")
 

--- a/dash_service/app.py
+++ b/dash_service/app.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from dash import Dash
 from flask import Flask, render_template, request, redirect,send_from_directory
 from sentry_sdk.integrations.flask import FlaskIntegration
+from urllib.parse import urlencode
 
 from . import admin, default_settings, register_extensions
 from .extensions import admin, db, login_manager
@@ -116,7 +117,8 @@ def reroute_transmonee_root():
 
 @server.route("/transmonee/<path:page>")
 def reroute_transmonee(page):
-    return redirect(f"/?prj=tm&page={page}")
+    query = urlencode({"prj": "tm", "page": page})
+    return redirect(f"/?{query}")
 
 
 app = Dash(


### PR DESCRIPTION
Potential fix for [https://github.com/unicef-drp/dash/security/code-scanning/3](https://github.com/unicef-drp/dash/security/code-scanning/3)

Use URL construction that safely encodes user-controlled input instead of string interpolation.

Best fix here (minimal behavior change): in `dash_service/app.py`, update the vulnerable redirect in `reroute_transmonee` to build the query string with `urllib.parse.urlencode`. This preserves current functionality (still redirects to `/?prj=tm&page=<value>`) while ensuring `page` is percent-encoded and cannot manipulate redirect structure.

Changes needed:
- Add `urlencode` import from Python standard library (`urllib.parse`).
- Replace line constructing `f"/?prj=tm&page={page}"` with encoded query generation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
