### PR TITLE
Potential fix for code scanning alert no. 2: URL redirection from remote source

### DIFF
--- a/dash_service/app.py
+++ b/dash_service/app.py
@@ -2,6 +2,7 @@ import sentry_sdk
 from dash import Dash
 from flask import Flask, render_template, request, redirect,send_from_directory
 from sentry_sdk.integrations.flask import FlaskIntegration
+from urllib.parse import urlencode
 
 from . import admin, default_settings, register_extensions
 from .extensions import admin, db, login_manager
@@ -108,7 +109,8 @@ def reroute_brazil(page):
 
 @server.route("/rosa/<path:page>")
 def reroute_rosa(page):
-    return redirect(f"/?prj=rosa&page={page}")
+    query = urlencode({"prj": "rosa", "page": page})
+    return redirect(f"/?{query}")
 
 @server.route("/transmonee")
 def reroute_transmonee_root():


### PR DESCRIPTION
Potential fix for [https://github.com/unicef-drp/dash/security/code-scanning/2](https://github.com/unicef-drp/dash/security/code-scanning/2)

Use URL construction that safely encodes user-controlled input instead of string interpolation.

Best fix here (minimal behavior change): in `dash_service/app.py`, update the vulnerable redirect in `reroute_rosa` to build the query string with `urllib.parse.urlencode`. This preserves current functionality (still redirects to `/?prj=rosa&page=<value>`) while ensuring `page` is percent-encoded and cannot manipulate redirect structure.

Changes needed:
- Add `urlencode` import from Python standard library (`urllib.parse`).
- Replace line constructing `f"/?prj=rosa&page={page}"` with encoded query generation.

Follows the same pattern as #158.