### PR TITLE
Bump dash to 2.15.0 and flask-cors to 6.0.0 (closes all 6 Dependabot alerts)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,13 @@
 
 orjson
 dash_treeview_antd
-dash==2.11.1
+dash==2.15.0
 dash-bootstrap-components==1.4.0
 dash-daq==0.5.0
 plotly==5.24.1
 
-flask-cors==3.0.10
+Flask<3
+flask-cors==6.0.0
 Flask-Admin==1.6.0
 flask-sqlalchemy==2.5.1
 Flask-Migrate==3.1.0


### PR DESCRIPTION
## Summary

Cohesive fix for all 6 open Dependabot alerts on this repo. Two version bumps plus one defensive pin on Flask.

- `dash==2.11.1` → `dash==2.15.0` — closes [alert #1](https://github.com/unicef-drp/dash/security/dependabot/1) (CVE-2024-21485 — dash XSS via `href`)
- `flask-cors==3.0.10` → `flask-cors==6.0.0` — closes alerts [#2](https://github.com/unicef-drp/dash/security/dependabot/2), [#3](https://github.com/unicef-drp/dash/security/dependabot/3), [#4](https://github.com/unicef-drp/dash/security/dependabot/4), [#5](https://github.com/unicef-drp/dash/security/dependabot/5), [#6](https://github.com/unicef-drp/dash/security/dependabot/6) (CVE-2024-1681, CVE-2024-6221 **high**, CVE-2024-6839, CVE-2024-6844, CVE-2024-6866)
- New: `Flask<3` — defensive pin (see below)

## Why the Flask pin

`flask-sqlalchemy==2.5.1` (already pinned in this file) imports `_app_ctx_stack` from Flask, which was removed in Flask 3.x. Without a Flask constraint, pip resolves Flask to 3.0.3 as a transitive dep, and the app fails to boot with:

```
ImportError: cannot import name '_app_ctx_stack' from 'flask'
```

I reproduced this locally, and it is the most likely cause of the [July 2 revert](https://github.com/unicef-drp/dash/commit/ef31193) of PR #157 (which added `Flask==2.3.3` for the same reason, but was also reverted — possibly because of unrelated pandas/pydantic env drift or an Azure-specific runtime issue I could not reproduce).

`Flask<3` (rather than `Flask==2.3.3`) is used so pip is free to pick the newest compatible Flask 2.x, which minimizes churn.

## Test plan

- [x] Fresh venv install of these requirements resolves cleanly
- [x] `python -m dash_service.dev_cli` boots without error
- [x] `from dash_service.wsgi import application` imports OK (this is the entrypoint Azure uses)
- [x] Smoke-tested routes: `/` → 200, `/login` → 200, `/brazil/foo` → 302, `/rosa/x` → 302, `/transmonee` → 302, `/transmonee/deep` → 302
- [ ] **Azure deploy dry-run recommended** before merge — my local venv is not identical to Azure App Service's Python runtime, and PR #157 passed CI but was reverted for an operational reason I could not identify from the code+CI alone. If the deploy behaves oddly, check the App Service log stream during startup for a Flask/Werkzeug import error.