### PR TITLE
Update Dash config for Drupal embedding

### DIFF
--- a/dash_service/assets/dynamic-load.js
+++ b/dash_service/assets/dynamic-load.js
@@ -217,8 +217,8 @@ if (browserOk) {
                         }
                         if (script.id == '_dash-config') {
                             config = JSON.parse(script.innerHTML);
-                            config["url_base_pathname"] = baseUrl;
-                            delete config["requests_pathname_prefix"];
+                            config["url_base_pathname"] = baseUrl.href;
+                            config["requests_pathname_prefix"] = baseUrl.pathname;
                             script.innerHTML = JSON.stringify(config);
                         }
                         scriptElement.innerHTML = script.innerHTML;


### PR DESCRIPTION
Updates the embedded Dash configuration after upgrading to Dash 2.15.

Testing whether restoring requests_pathname_prefix resolves the asset loading issue in the Drupal embed.