### PR TITLE
Test Plotly config for embedded Dash app

### DIFF
--- a/dash_service/assets/dynamic-load.js
+++ b/dash_service/assets/dynamic-load.js
@@ -218,6 +218,12 @@ if (browserOk) {
                         if (script.id == '_dash-config') {
                             config = JSON.parse(script.innerHTML);
                             config["url_base_pathname"] = baseUrl;
+                            config["serve_locally"] = false;
+                            config["plotlyjs_url"] = new URL(
+                                "/_dash-component-suites/plotly/package_data/plotly.min.js",
+                                baseUrl
+                            ).href;
+
                             delete config["requests_pathname_prefix"];
                             script.innerHTML = JSON.stringify(config);
                         }


### PR DESCRIPTION
This is an experimental change to investigate the Plotly loading issue introduced after upgrading Dash to 2.15.

The change modifies the injected _dash-config in dynamic-load.js to test whether forcing serve_locally = false and explicitly setting plotlyjs_url resolves the missing Plotly assets when the dashboard is embedded in Drupal.

The dashboard continues to work when accessed directly through the Azure App Service. This change is intended to determine whether the issue lies in the client-side Dash configuration used by the embedded version.